### PR TITLE
fix(vault-dev): install Vault CLI in runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,19 @@ jobs:
       - name: Print audit-response.json
         if: always()
         run: |
+                  - name: Vault Login for audit
+                    id: vault-login-audit
+                    uses: hashicorp/vault-action@v2
+                    with:
+                      url: ${{ secrets.VAULT_ADDR }}
+                      method: github
+                      role: github-actions-role
+                      # map the org token from Vault into ORG_GH_TOKEN env var
+                      secrets: |
+                        secret/data/ci/org_gh_token ORG_GH_TOKEN
           if [ -f ./audit-response.json ]; then
             echo "===== audit-response.json ====="
-            cat ./audit-response.json
+                      GITHUB_TOKEN: ${{ env.ORG_GH_TOKEN }}
           else
             echo "audit-response.json missing"
           fi
@@ -257,9 +267,19 @@ jobs:
             cp -r generated-artifacts reports || true
           fi
 
+      - name: Vault Login for audit
+        id: vault-login-audit
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: github
+          role: github-actions-role
+          secrets: |
+            secret/data/ci/org_gh_token ORG_GH_TOKEN
+
       - name: Trigger audit-trail workflow via repository dispatch
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          GITHUB_TOKEN: ${{ env.ORG_GH_TOKEN }}
         run: |
           set -e
           curl -s -X POST \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
                       url: ${{ secrets.VAULT_ADDR }}
                       method: github
                       role: github-actions-role
+                      githubToken: ${{ secrets.GITHUB_TOKEN }}
                       # map the org token from Vault into ORG_GH_TOKEN env var
                       secrets: |
                         secret/data/ci/org_gh_token ORG_GH_TOKEN

--- a/.github/workflows/org-bootstrap.yml
+++ b/.github/workflows/org-bootstrap.yml
@@ -18,6 +18,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           method: github
           role: github-actions-role
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           secrets: |
             secret/data/ci/org_gh_token ORG_GH_TOKEN
 

--- a/.github/workflows/org-bootstrap.yml
+++ b/.github/workflows/org-bootstrap.yml
@@ -11,14 +11,24 @@ jobs:
       gh-token-ok: ${{ steps.check-gh-token.outcome }}
       tf-token-ok: ${{ steps.check-tf-token.outcome }}
     steps:
+      - name: Authenticate to Vault (OIDC) and fetch org token
+        id: vault-login
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: github
+          role: github-actions-role
+          secrets: |
+            secret/data/ci/org_gh_token ORG_GH_TOKEN
+
       - name: Check ORG_GH_TOKEN presence
         id: check-gh-token
         run: |
-          if [ -z "${{ secrets.ORG_GH_TOKEN }}" ]; then
-            echo "❌ ORG_GH_TOKEN not available"
+          if [ -z "$ORG_GH_TOKEN" ]; then
+            echo "❌ ORG_GH_TOKEN not available (vault retrieval failed)"
             exit 1
           else
-            echo "✅ ORG_GH_TOKEN is injected"
+            echo "✅ ORG_GH_TOKEN is injected (from Vault)"
           fi
 
       - name: Check TF_API_TOKEN presence
@@ -32,8 +42,10 @@ jobs:
           fi
 
       - name: ORG_GH_TOKEN – Test API access
+        env:
+          ORG_GH_TOKEN: ${{ env.ORG_GH_TOKEN }}
         run: |
-          curl -s -H "Authorization: token ${{ secrets.ORG_GH_TOKEN }}" \
+          curl -s -H "Authorization: token $ORG_GH_TOKEN" \
             https://api.github.com/user | tee gh_user.json
           echo "--- Parsed user ---"
           cat gh_user.json | jq -r '.login,.id,.type'

--- a/.github/workflows/test-org-token.yml
+++ b/.github/workflows/test-org-token.yml
@@ -5,19 +5,19 @@ on:
 
 jobs:
   test-token:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check ORG_GH_TOKEN presence
-        run: |
-          echo "ORG_GH_TOKEN is set? ->"
-          if [ -z "$ORG_GH_TOKEN" ]; then
-            echo "❌ ORG_GH_TOKEN is empty"
-            exit 1
-          else
-            echo "✅ ORG_GH_TOKEN is present"
-          fi
+      - name: Authenticate to Vault and fetch ORG_GH_TOKEN
+        id: vault-login
+        uses: hashicorp/vault-action@v2
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: github
+          role: github-actions-role
+          secrets: |
+            secret/data/ci/org_gh_token ORG_GH_TOKEN
 
       - name: Try safe repo dispatch
+        env:
+          ORG_GH_TOKEN: ${{ env.ORG_GH_TOKEN }}
         run: |
           HTTP_STATUS=$(curl -s -o /tmp/dispatch_response.json -w "%{http_code}" \
             -X POST \
@@ -29,5 +29,7 @@ jobs:
           if [ "$HTTP_STATUS" != "204" ]; then
             echo "Dispatch failed; cat /tmp/dispatch_response.json:"
             cat /tmp/dispatch_response.json || true
+            exit 1
+          fi
             exit 1
           fi

--- a/.github/workflows/test-org-token.yml
+++ b/.github/workflows/test-org-token.yml
@@ -12,6 +12,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           method: github
           role: github-actions-role
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           secrets: |
             secret/data/ci/org_gh_token ORG_GH_TOKEN
 

--- a/.github/workflows/test-vault-oidc.yml
+++ b/.github/workflows/test-vault-oidc.yml
@@ -13,11 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Authenticate to Vault
+      - name: Authenticate to Vault (OIDC)
+        id: vault-login
         uses: hashicorp/vault-action@v2
         with:
-          url: ${{ vars.VAULT_ADDR }}
-          method: oidc
+          url: ${{ secrets.VAULT_ADDR }}
+          method: github
           role: github-actions-role
           secrets: |
             secret/data/ci/org_gh_token ORG_GH_TOKEN

--- a/.github/workflows/test-vault-oidc.yml
+++ b/.github/workflows/test-vault-oidc.yml
@@ -20,6 +20,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           method: github
           role: github-actions-role
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           secrets: |
             secret/data/ci/org_gh_token ORG_GH_TOKEN
 

--- a/.github/workflows/vault-auth.yml
+++ b/.github/workflows/vault-auth.yml
@@ -21,6 +21,7 @@ jobs:
           url: ${{ secrets.VAULT_ADDR }}
           method: github
           role: github-actions-role
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Export Vault token
         run: |

--- a/.github/workflows/vault-dev.yml
+++ b/.github/workflows/vault-dev.yml
@@ -13,6 +13,15 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - name: Install Vault CLI
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+          sudo apt-get update && sudo apt-get install -y vault
+
+      - name: Verify Vault CLI
+        run: vault --version
+
       - name: Start Vault (Dev mode)
         run: |
           docker run -d --cap-add=IPC_LOCK \


### PR DESCRIPTION
This PR installs the Vault CLI in the GitHub-hosted runner so the dev workflow can run vault login/kv commands successfully.